### PR TITLE
fix: add ignore_ssl option and improve TLS diagnostics

### DIFF
--- a/custom_components/unraid/__init__.py
+++ b/custom_components/unraid/__init__.py
@@ -31,6 +31,7 @@ from unraid_api.exceptions import (
 )
 
 from .const import (
+    CONF_IGNORE_SSL,
     DEFAULT_PORT,
     DOMAIN,
     REPAIR_AUTH_FAILED,
@@ -115,10 +116,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: UnraidConfigEntry) -> bo
     port = entry.data.get(CONF_PORT, DEFAULT_PORT)
     api_key = entry.data[CONF_API_KEY]
     use_ssl = entry.data.get(CONF_SSL, True)
+    ignore_ssl = entry.data.get(CONF_IGNORE_SSL, False)
+
+    _LOGGER.debug(
+        "Starting setup for %s with http_port=%s ssl=%s ignore_ssl=%s",
+        host,
+        port,
+        use_ssl,
+        ignore_ssl,
+    )
 
     # Get HA's aiohttp session for proper connection pooling
-    # Use verify_ssl based on whether SSL connection was established
-    session = async_get_clientsession(hass, verify_ssl=use_ssl)
+    # Verify certificates unless explicitly disabled by user/config flow fallback
+    session = async_get_clientsession(hass, verify_ssl=not ignore_ssl)
 
     # Create API client with injected session (using unraid_api library >=1.5.0).
     # The library handles SSL detection automatically via HTTP probe.
@@ -126,7 +136,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: UnraidConfigEntry) -> bo
         host=host,
         http_port=port,
         api_key=api_key,
-        verify_ssl=use_ssl,
+        verify_ssl=not ignore_ssl,
         session=session,
     )
 
@@ -136,6 +146,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: UnraidConfigEntry) -> bo
         info = await api_client.get_server_info()
         # Clear any previous auth repair issues on successful connection
         ir.async_delete_issue(hass, DOMAIN, REPAIR_AUTH_FAILED)
+        _LOGGER.debug("Initial API connectivity check succeeded for %s", host)
     except UnraidAuthenticationError as err:
         await api_client.close()
         # Create repair issue for auth failure
@@ -153,10 +164,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: UnraidConfigEntry) -> bo
         raise ConfigEntryAuthFailed(msg) from err
     except UnraidSSLError as err:
         await api_client.close()
+        _LOGGER.warning(
+            "TLS verification failed for %s (ignore_ssl=%s): %s",
+            host,
+            ignore_ssl,
+            err,
+        )
         msg = f"SSL certificate error connecting to Unraid server {host}: {err}"
         raise ConfigEntryNotReady(msg) from err
     except (UnraidConnectionError, UnraidTimeoutError) as err:
         await api_client.close()
+        _LOGGER.warning("Connection to %s failed: %s", host, err)
         msg = f"Failed to connect to Unraid server: {err}"
         raise ConfigEntryNotReady(msg) from err
     except UnraidAPIError as err:

--- a/custom_components/unraid/config_flow.py
+++ b/custom_components/unraid/config_flow.py
@@ -23,6 +23,7 @@ from unraid_api.exceptions import (
 )
 
 from .const import (
+    CONF_IGNORE_SSL,
     CONF_UPS_CAPACITY_VA,
     CONF_UPS_NOMINAL_POWER,
     DEFAULT_PORT,
@@ -52,7 +53,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize the config flow."""
         self._server_uuid: str | None = None
         self._server_hostname: str | None = None
-        self._use_ssl: bool = True  # Track whether SSL connection succeeded
+        self._use_ssl: bool = True  # Track whether HTTPS is used
+        self._ignore_ssl: bool = False  # Track whether TLS verification is disabled
 
     @staticmethod
     def async_get_options_flow(
@@ -125,6 +127,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_PORT: user_input.get(CONF_PORT, DEFAULT_PORT),
                         CONF_API_KEY: user_input[CONF_API_KEY],
                         CONF_SSL: self._use_ssl,
+                        CONF_IGNORE_SSL: self._ignore_ssl,
                     },
                     options={
                         CONF_UPS_CAPACITY_VA: DEFAULT_UPS_CAPACITY_VA,
@@ -140,6 +143,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Coerce(int), vol.Range(min=MIN_PORT, max=MAX_PORT)
                 ),
                 vol.Required(CONF_API_KEY): str,
+                vol.Optional(CONF_IGNORE_SSL, default=False): bool,
             }
         )
 
@@ -186,10 +190,20 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         api_key = user_input[CONF_API_KEY].strip()
         port = user_input.get(CONF_PORT, DEFAULT_PORT)
 
-        # Reset SSL state to default
-        self._use_ssl = True
+        ignore_ssl = bool(user_input.get(CONF_IGNORE_SSL, False))
 
-        session = async_get_clientsession(self.hass, verify_ssl=True)
+        # Reset state to defaults for this connection attempt
+        self._use_ssl = True
+        self._ignore_ssl = ignore_ssl
+
+        _LOGGER.debug(
+            "Connection test config for %s: http_port=%s ignore_ssl=%s",
+            host,
+            port,
+            ignore_ssl,
+        )
+
+        session = async_get_clientsession(self.hass, verify_ssl=not ignore_ssl)
 
         # Let the library's HTTP probe discover the SSL/TLS mode.
         # Pass the user's port as http_port; library defaults https_port=443.
@@ -197,19 +211,21 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             host=host,
             api_key=api_key,
             http_port=port,
-            verify_ssl=True,
+            verify_ssl=not ignore_ssl,
             session=session,
         )
 
         try:
             await self._validate_connection(api_client, host)
-        except SSLCertificateError as err:
-            _LOGGER.debug(
-                "SSL verification failed for %s, retrying with verify_ssl=False: %s",
-                host,
-                err,
-            )
+        except SSLCertificateError:
             await api_client.close()
+            if ignore_ssl:
+                raise
+
+            _LOGGER.info(
+                "TLS verification failed for %s; retrying with ignore_ssl enabled",
+                host,
+            )
             session = async_get_clientsession(self.hass, verify_ssl=False)
             fallback_client = UnraidClient(
                 host=host,
@@ -220,15 +236,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             try:
                 await self._validate_connection(fallback_client, host)
-                # Success with SSL verification disabled
-                self._use_ssl = False
-                _LOGGER.info(
-                    "Connected to %s with self-signed cert (SSL verify disabled)",
+                self._ignore_ssl = True
+                _LOGGER.warning(
+                    "Connected to %s with TLS verification disabled "
+                    "(self-signed certificate accepted)",
                     host,
                 )
-            except CannotConnectError as fallback_err:
-                # Keep original failure reason if fallback also fails
-                raise err from fallback_err
             finally:
                 await fallback_client.close()
         except Exception:
@@ -253,15 +266,21 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except (InvalidAuthError, CannotConnectError, UnsupportedVersionError):
             raise
         except UnraidVersionError as err:
+            _LOGGER.warning(
+                "Unsupported Unraid/API version reported by %s: %s", host, err
+            )
             msg = str(err)
             raise UnsupportedVersionError(msg) from err
         except UnraidAuthenticationError as err:
+            _LOGGER.warning("Authentication failed while validating %s: %s", host, err)
             msg = "Invalid API key or insufficient permissions"
             raise InvalidAuthError(msg) from err
         except UnraidSSLError as err:
+            _LOGGER.warning("TLS verification failed for %s: %s", host, err)
             msg = f"SSL certificate error for {host}: {err}"
             raise SSLCertificateError(msg) from err
         except (UnraidConnectionError, UnraidTimeoutError) as err:
+            _LOGGER.warning("Network connectivity test failed for %s: %s", host, err)
             msg = f"Cannot connect to {host} - {err}"
             raise CannotConnectError(msg) from err
         except aiohttp.ClientResponseError as err:
@@ -342,6 +361,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_HOST: reauth_entry.data[CONF_HOST],
                 CONF_PORT: reauth_entry.data.get(CONF_PORT, DEFAULT_PORT),
                 CONF_API_KEY: user_input[CONF_API_KEY],
+                CONF_IGNORE_SSL: reauth_entry.data.get(CONF_IGNORE_SSL, False),
             }
 
             try:
@@ -352,7 +372,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                 return self.async_update_reload_and_abort(
                     reauth_entry,
-                    data_updates={**user_input, CONF_SSL: self._use_ssl},
+                    data_updates={
+                        **user_input,
+                        CONF_SSL: self._use_ssl,
+                        CONF_IGNORE_SSL: self._ignore_ssl,
+                    },
                     reason="reauth_successful",
                 )
 
@@ -391,7 +415,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                     return self.async_update_reload_and_abort(
                         reconfigure_entry,
-                        data_updates={**user_input, CONF_SSL: self._use_ssl},
+                        data_updates={
+                            **user_input,
+                            CONF_SSL: self._use_ssl,
+                            CONF_IGNORE_SSL: self._ignore_ssl,
+                        },
                     )
 
                 except InvalidAuthError:
@@ -417,6 +445,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         default=reconfigure_entry.data.get(CONF_PORT, DEFAULT_PORT),
                     ): vol.All(vol.Coerce(int), vol.Range(min=MIN_PORT, max=MAX_PORT)),
                     vol.Required(CONF_API_KEY): str,
+                    vol.Optional(
+                        CONF_IGNORE_SSL,
+                        default=reconfigure_entry.data.get(CONF_IGNORE_SSL, False),
+                    ): bool,
                 }
             ),
             errors=errors,

--- a/custom_components/unraid/const.py
+++ b/custom_components/unraid/const.py
@@ -65,6 +65,7 @@ PLACEHOLDER_UUIDS: Final = frozenset(
 # =============================================================================
 CONF_UPS_CAPACITY_VA: Final = "ups_capacity_va"
 CONF_UPS_NOMINAL_POWER: Final = "ups_nominal_power"
+CONF_IGNORE_SSL: Final = "ignore_ssl"
 
 # =============================================================================
 # Default Values

--- a/custom_components/unraid/strings.json
+++ b/custom_components/unraid/strings.json
@@ -8,12 +8,14 @@
         "data": {
           "host": "Host",
           "port": "Port",
-          "api_key": "API key"
+          "api_key": "API key",
+          "ignore_ssl": "Ignore SSL/TLS certificate validation"
         },
         "data_description": {
           "host": "IP address (for example, 192.168.1.100) or hostname/domain of your Unraid server.",
           "port": "HTTP port number (default: 80). Secure connections are handled automatically.",
-          "api_key": "Generate in Unraid Settings → Management Access → API Keys. Requires ADMIN role."
+          "api_key": "Generate in Unraid Settings \u2192 Management Access \u2192 API Keys. Requires ADMIN role.",
+          "ignore_ssl": "Enable only if your Unraid server uses a self-signed certificate. This keeps HTTPS but skips certificate trust checks."
         }
       },
       "reauth_confirm": {
@@ -23,7 +25,7 @@
           "api_key": "API key"
         },
         "data_description": {
-          "api_key": "Generate a new API key in Unraid Settings → Management Access → API Keys"
+          "api_key": "Generate a new API key in Unraid Settings \u2192 Management Access \u2192 API Keys"
         }
       },
       "reconfigure": {
@@ -32,12 +34,14 @@
         "data": {
           "host": "Host",
           "port": "Port",
-          "api_key": "API key"
+          "api_key": "API key",
+          "ignore_ssl": "Ignore SSL/TLS certificate validation"
         },
         "data_description": {
           "host": "IP address or hostname of your Unraid server.",
           "port": "HTTP port number (default: 80). Secure connections are handled automatically.",
-          "api_key": "API key with ADMIN role permissions."
+          "api_key": "API key with ADMIN role permissions.",
+          "ignore_ssl": "Enable only if your Unraid server uses a self-signed certificate. This keeps HTTPS but skips certificate trust checks."
         }
       }
     },
@@ -69,7 +73,7 @@
         },
         "data_description": {
           "ups_capacity_va": "Optional. Your UPS VA rating (e.g., 1000 for a 1000VA UPS). Shown in sensor attributes for reference.",
-          "ups_nominal_power": "Required for UPS Power sensor. Enter the Watts value from your UPS specs. If Unraid only shows VA, check your UPS label or estimate using VA × 0.6."
+          "ups_nominal_power": "Required for UPS Power sensor. Enter the Watts value from your UPS specs. If Unraid only shows VA, check your UPS label or estimate using VA \u00d7 0.6."
         }
       }
     },

--- a/custom_components/unraid/translations/en.json
+++ b/custom_components/unraid/translations/en.json
@@ -8,12 +8,14 @@
         "data": {
           "host": "Host",
           "port": "Port",
-          "api_key": "API key"
+          "api_key": "API key",
+          "ignore_ssl": "Ignore SSL/TLS certificate validation"
         },
         "data_description": {
           "host": "IP address (for example, 192.168.1.100) or hostname/domain of your Unraid server.",
           "port": "HTTP port number (default: 80). Secure connections are handled automatically.",
-          "api_key": "Generate in Unraid Settings → Management Access → API Keys. Requires ADMIN role."
+          "api_key": "Generate in Unraid Settings \u2192 Management Access \u2192 API Keys. Requires ADMIN role.",
+          "ignore_ssl": "Enable only if your Unraid server uses a self-signed certificate. This keeps HTTPS but skips certificate trust checks."
         }
       },
       "reauth_confirm": {
@@ -23,7 +25,7 @@
           "api_key": "API key"
         },
         "data_description": {
-          "api_key": "Generate a new API key in Unraid Settings → Management Access → API Keys"
+          "api_key": "Generate a new API key in Unraid Settings \u2192 Management Access \u2192 API Keys"
         }
       },
       "reconfigure": {
@@ -32,12 +34,14 @@
         "data": {
           "host": "Host",
           "port": "Port",
-          "api_key": "API key"
+          "api_key": "API key",
+          "ignore_ssl": "Ignore SSL/TLS certificate validation"
         },
         "data_description": {
           "host": "IP address or hostname of your Unraid server.",
           "port": "HTTP port number (default: 80). Secure connections are handled automatically.",
-          "api_key": "API key with ADMIN role permissions."
+          "api_key": "API key with ADMIN role permissions.",
+          "ignore_ssl": "Enable only if your Unraid server uses a self-signed certificate. This keeps HTTPS but skips certificate trust checks."
         }
       }
     },
@@ -69,7 +73,7 @@
         },
         "data_description": {
           "ups_capacity_va": "Optional. Your UPS VA rating (e.g., 1000 for a 1000VA UPS). Shown in sensor attributes for reference.",
-          "ups_nominal_power": "Required for UPS Power sensor. Enter the Watts value from your UPS specs. If Unraid only shows VA, check your UPS label or estimate using VA × 0.6."
+          "ups_nominal_power": "Required for UPS Power sensor. Enter the Watts value from your UPS specs. If Unraid only shows VA, check your UPS label or estimate using VA \u00d7 0.6."
         }
       }
     },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -25,6 +25,7 @@ from unraid_api.models import ServerInfo, UPSDevice, VersionInfo
 
 from custom_components.unraid.config_flow import CannotConnectError, SSLCertificateError
 from custom_components.unraid.const import (
+    CONF_IGNORE_SSL,
     CONF_UPS_CAPACITY_VA,
     CONF_UPS_NOMINAL_POWER,
     DEFAULT_PORT,
@@ -94,6 +95,7 @@ async def test_user_step_form_includes_port_field(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert "port" in result["data_schema"].schema
+    assert "ignore_ssl" in result["data_schema"].schema
 
 
 async def test_successful_connection(
@@ -118,6 +120,7 @@ async def test_successful_connection(
         "port": DEFAULT_PORT,
         "api_key": "valid-api-key",
         "ssl": True,
+        "ignore_ssl": False,
     }
 
 
@@ -146,6 +149,7 @@ async def test_successful_connection_with_custom_port(
         "port": 8080,
         "api_key": "valid-api-key",
         "ssl": True,
+        "ignore_ssl": False,
     }
     mock_client_class.assert_called_with(
         host="unraid.local",
@@ -178,6 +182,36 @@ async def test_connection_uses_default_port_when_not_specified(
         api_key="valid-api-key",
         http_port=DEFAULT_PORT,
         verify_ssl=True,
+        session=mock_client_class.call_args.kwargs["session"],
+    )
+
+
+async def test_successful_connection_with_ignore_ssl(
+    hass: HomeAssistant, mock_setup_entry: None, mock_api_client: MagicMock
+) -> None:
+    """Test successful connection with ignore SSL enabled."""
+    with patch(
+        "custom_components.unraid.config_flow.UnraidClient",
+        return_value=mock_api_client,
+    ) as mock_client_class:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={
+                "host": "unraid.local",
+                "port": 80,
+                "api_key": "valid-api-key",
+                "ignore_ssl": True,
+            },
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_IGNORE_SSL] is True
+    mock_client_class.assert_called_with(
+        host="unraid.local",
+        api_key="valid-api-key",
+        http_port=80,
+        verify_ssl=False,
         session=mock_client_class.call_args.kwargs["session"],
     )
 
@@ -692,7 +726,8 @@ async def test_ssl_error_retries_with_verify_disabled(
     created_clients[1].close.assert_awaited_once()
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["result"].unique_id == "test-uuid"
-    assert result2["data"]["ssl"] is False  # SSL verification disabled for self-signed
+    assert result2["data"]["ssl"] is True
+    assert result2["data"]["ignore_ssl"] is True
 
 
 async def test_non_ssl_connection_error_does_not_retry_with_verify_disabled(
@@ -898,6 +933,7 @@ async def test_reauth_flow_adds_ssl_flag_for_legacy_entries(
     assert result2["type"] is FlowResultType.ABORT
     assert result2["reason"] == "reauth_successful"
     assert entry.data[CONF_SSL] is True
+    assert entry.data[CONF_IGNORE_SSL] is False
 
 
 async def test_reauth_flow_updates_ssl_flag_when_cert_changes(
@@ -948,8 +984,8 @@ async def test_reauth_flow_updates_ssl_flag_when_cert_changes(
 
     assert result2["type"] is FlowResultType.ABORT
     assert result2["reason"] == "reauth_successful"
-    # SSL flag should be updated to False since cert verification failed
-    assert entry.data[CONF_SSL] is False
+    assert entry.data[CONF_SSL] is True
+    assert entry.data[CONF_IGNORE_SSL] is True
 
 
 async def test_reauth_flow_invalid_key(
@@ -1398,7 +1434,8 @@ async def test_reconfigure_flow_updates_ssl_flag_when_cert_changes(
     assert result2["reason"] == "reconfigure_successful"
     assert entry.data[CONF_HOST] == "192.168.1.100"
     assert entry.data[CONF_API_KEY] == "new-key"
-    assert entry.data[CONF_SSL] is False
+    assert entry.data[CONF_SSL] is True
+    assert entry.data[CONF_IGNORE_SSL] is True
 
 
 async def test_reconfigure_flow_connection_error(
@@ -1630,6 +1667,7 @@ async def test_reconfigure_flow_shows_port_field(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reconfigure"
     assert "port" in result["data_schema"].schema
+    assert "ignore_ssl" in result["data_schema"].schema
 
 
 async def test_reconfigure_flow_updates_port(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -17,7 +17,7 @@ from custom_components.unraid import (
     async_setup_entry,
     async_unload_entry,
 )
-from custom_components.unraid.const import DEFAULT_PORT, DOMAIN
+from custom_components.unraid.const import CONF_IGNORE_SSL, DEFAULT_PORT, DOMAIN
 
 # =============================================================================
 # Fixtures
@@ -35,6 +35,7 @@ def mock_config_entry() -> MockConfigEntry:
             CONF_API_KEY: "test-api-key",
             CONF_PORT: DEFAULT_PORT,
             CONF_SSL: True,
+            CONF_IGNORE_SSL: False,
         },
         options={},
         unique_id="test-uuid-123",
@@ -216,6 +217,41 @@ async def test_setup_entry_creates_coordinators(
     mock_infra_coord.assert_called_once()
 
 
+async def test_setup_entry_uses_ignore_ssl_for_session(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_unraid_client: MagicMock,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test setup disables TLS verification when ignore SSL is configured."""
+    mock_config_entry.data[CONF_IGNORE_SSL] = True
+    mock_config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "custom_components.unraid.UnraidSystemCoordinator",
+            return_value=mock_coordinator,
+        ),
+        patch(
+            "custom_components.unraid.UnraidStorageCoordinator",
+            return_value=mock_coordinator,
+        ),
+        patch(
+            "custom_components.unraid.UnraidInfraCoordinator",
+            return_value=mock_coordinator,
+        ),
+        patch("custom_components.unraid.async_get_clientsession") as mock_session,
+        patch.object(
+            hass.config_entries, "async_forward_entry_setups", return_value=None
+        ),
+    ):
+        mock_session.return_value = MagicMock()
+        result = await async_setup_entry(hass, mock_config_entry)
+
+    assert result is True
+    mock_session.assert_called_with(hass, verify_ssl=False)
+
+
 # =============================================================================
 # Unload Entry Tests
 # =============================================================================
@@ -389,6 +425,7 @@ async def test_setup_entry_builds_configuration_url_from_lan_ip(
             CONF_HOST: "192.168.1.100",
             CONF_API_KEY: "test-api-key",
             CONF_SSL: True,
+            CONF_IGNORE_SSL: False,
         },
         unique_id="test-uuid",
     )


### PR DESCRIPTION
### Motivation

- Allow users to explicitly opt-in to ignoring TLS certificate verification for Unraid servers using self-signed certificates and surface clearer diagnostics when TLS verification fails.

### Description

- Add a new `CONF_IGNORE_SSL` (`"ignore_ssl"`) constant and expose an `ignore_ssl` boolean in the config flow `user` and `reconfigure` forms, and persist it on entry create/update.
- Honor `ignore_ssl` in runtime setup by passing `verify_ssl=not ignore_ssl` to `async_get_clientsession` and `UnraidClient`, and add debug logging for the configured connection flags.
- Keep the existing auto-fallback behavior: on a certificate verification error the flow will retry once with verification disabled and persist `ignore_ssl=True` when that fallback succeeds, and added clearer info/warning logs for these events.
- Improve logging in the connection validation path to provide warnings for unsupported versions, authentication failures, TLS verification failures, and network connectivity issues.
- Add UI strings explaining the new `ignore_ssl` option in `strings.json` and the generated `translations/en.json`.
- Update and add unit tests covering the new form field, behavior when `ignore_ssl` is provided, the fallback path that sets `ignore_ssl` on success, and that `async_setup_entry` uses `ignore_ssl` when creating the aiohttp session.

### Testing

- Ran `ruff` checks and formatting (`ruff check --fix` / `ruff format`) which passed after fixes.
- Verified Python modules compile with `python -m py_compile` (success).
- Attempted to run `pytest -q tests/test_config_flow.py tests/test_init.py` but the environment lacks the `pytest_homeassistant_custom_component` dependency so tests could not be executed here; unit tests were added/updated to cover the new behavior.
- `./script/lint` was not runnable in this environment because the project virtualenv is not bootstrapped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8273a5028832bb2469a36720f3241)