### PR TITLE
fix: improve TLS guidance and avoid version-check false negatives

### DIFF
--- a/custom_components/unraid/__init__.py
+++ b/custom_components/unraid/__init__.py
@@ -165,7 +165,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: UnraidConfigEntry) -> bo
     except UnraidSSLError as err:
         await api_client.close()
         _LOGGER.warning(
-            "TLS verification failed for %s (ignore_ssl=%s): %s",
+            "TLS verification failed for %s (ignore_ssl=%s): %s. "
+            "If you use a self-signed certificate, enable 'Ignore SSL/TLS "
+            "certificate validation' in Reconfigure.",
             host,
             ignore_ssl,
             err,

--- a/custom_components/unraid/config_flow.py
+++ b/custom_components/unraid/config_flow.py
@@ -42,6 +42,36 @@ _LOGGER = logging.getLogger(__name__)
 MAX_HOSTNAME_LEN = 253
 MIN_PORT = 1
 MAX_PORT = 65535
+MIN_UNRAID_VERSION = (7, 2, 0)
+MIN_API_VERSION = (4, 21, 0)
+
+
+def _parse_version(version: str | None) -> tuple[int, ...] | None:
+    """Parse dotted semantic-ish version strings into integer tuples."""
+    if not version:
+        return None
+
+    parts: list[int] = []
+    for segment in version.split("."):
+        digits = "".join(char for char in segment if char.isdigit())
+        if not digits:
+            break
+        parts.append(int(digits))
+
+    return tuple(parts) if parts else None
+
+
+def _is_compatible_version(
+    unraid_version: str | None, api_version: str | None
+) -> bool:
+    """Return whether the supplied versions meet minimum requirements."""
+    parsed_unraid = _parse_version(unraid_version)
+    parsed_api = _parse_version(api_version)
+
+    if parsed_unraid is None or parsed_api is None:
+        return False
+
+    return parsed_unraid >= MIN_UNRAID_VERSION and parsed_api >= MIN_API_VERSION
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -266,11 +296,28 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except (InvalidAuthError, CannotConnectError, UnsupportedVersionError):
             raise
         except UnraidVersionError as err:
+            _LOGGER.warning("Compatibility check failed for %s: %s", host, err)
+            server_info = await api_client.get_server_info()
+
+            if _is_compatible_version(server_info.sw_version, server_info.api_version):
+                _LOGGER.warning(
+                    "Proceeding with %s despite compatibility check failure; "
+                    "server reports Unraid=%s API=%s",
+                    host,
+                    server_info.sw_version,
+                    server_info.api_version,
+                )
+                await self._fetch_server_info(api_client, host)
+                return
+
             _LOGGER.warning(
-                "Unsupported Unraid/API version reported by %s: %s", host, err
+                "Unraid/API versions for %s are below minimum or unreadable "
+                "(Unraid=%s API=%s)",
+                host,
+                server_info.sw_version,
+                server_info.api_version,
             )
-            msg = str(err)
-            raise UnsupportedVersionError(msg) from err
+            raise UnsupportedVersionError(str(err)) from err
         except UnraidAuthenticationError as err:
             _LOGGER.warning("Authentication failed while validating %s: %s", host, err)
             msg = "Invalid API key or insufficient permissions"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1602,6 +1602,54 @@ async def test_reconfigure_flow_unsupported_version_error(
     assert result2["errors"]["base"] == "unsupported_version"
 
 
+async def test_reconfigure_flow_allows_when_reported_versions_are_supported(
+    hass: HomeAssistant, mock_setup_entry: None
+) -> None:
+    """Test reconfigure succeeds when compatibility check is a false negative."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="tower",
+        data={CONF_HOST: "unraid.local", CONF_API_KEY: "old-key"},
+        options={},
+        unique_id="test-uuid",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": entry.entry_id,
+        },
+    )
+
+    mock_api = AsyncMock()
+    mock_api.test_connection = AsyncMock()
+    mock_api.check_compatibility = AsyncMock(
+        side_effect=UnraidVersionError("Unraid version not supported")
+    )
+    mock_api.get_server_info = AsyncMock(
+        return_value=ServerInfo(
+            uuid="test-uuid",
+            hostname="tower",
+            sw_version="7.2.2",
+            api_version="4.29.2",
+        )
+    )
+    mock_api.close = AsyncMock()
+
+    with patch(
+        "custom_components.unraid.config_flow.UnraidClient", return_value=mock_api
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: "192.168.1.100", CONF_API_KEY: "new-key"},
+        )
+
+    assert result2["type"] is FlowResultType.ABORT
+    assert result2["reason"] == "reconfigure_successful"
+
+
 async def test_reconfigure_flow_unknown_error(
     hass: HomeAssistant, mock_setup_entry: None
 ) -> None:


### PR DESCRIPTION
### Motivation
- Users hit TLS verification failures when connecting to Unraid by IP while the certificate is issued to a hostname, and need an explicit path to ignore TLS verification when desired.  
- The config flow could surface false "unsupported version" errors when the library's `check_compatibility()` raised `UnraidVersionError` even though `get_server_info()` reports compatible versions (e.g. Unraid 7.2.2 / API 4.29.2).  
- Improve observability and avoid blocking valid reconfigures while still rejecting truly unsupported servers.  

### Description
- Add version-parsing helpers `_parse_version()` and `_is_compatible_version()` and constants `MIN_UNRAID_VERSION` / `MIN_API_VERSION` to validate reported server versions.  
- When `check_compatibility()` raises `UnraidVersionError`, fetch `get_server_info()` and proceed if the server-reported `sw_version` and `api_version` meet minimums; otherwise raise `UnsupportedVersionError` as before.  
- Improve TLS logging during setup to include actionable guidance pointing users to the Reconfigure option `Ignore SSL/TLS certificate validation` when a `UnraidSSLError` occurs.  
- Add a test `test_reconfigure_flow_allows_when_reported_versions_are_supported` to cover the false-negative compatibility path in the reconfigure flow.  
- Modified files: `custom_components/unraid/config_flow.py`, `custom_components/unraid/__init__.py`, `tests/test_config_flow.py`.  

### Testing
- Ran Python compilation check: `python -m py_compile custom_components/unraid/config_flow.py custom_components/unraid/__init__.py tests/test_config_flow.py` (succeeded).  
- Attempted project lint: `./script/lint` (environment: virtualenv not found; lint not executed in this environment).  
- Attempted targeted pytest run: `pytest -q tests/test_config_flow.py -k "reconfigure_flow_unsupported_version_error or reported_versions_are_supported"` (failed to run here due to missing `pytest_homeassistant_custom_component` dependency in the environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b84959cd6c832bbd8b0ce94987b5e5)