### PR TITLE
Persist `ignore_ssl` flag, normalize legacy `ssl=False`, and improve TLS fallback/logging

### DIFF
--- a/custom_components/unraid/__init__.py
+++ b/custom_components/unraid/__init__.py
@@ -31,6 +31,7 @@ from unraid_api.exceptions import (
 )
 
 from .const import (
+    CONF_IGNORE_SSL,
     DEFAULT_PORT,
     DOMAIN,
     REPAIR_AUTH_FAILED,
@@ -118,10 +119,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: UnraidConfigEntry) -> bo
     port = entry.data.get(CONF_PORT, DEFAULT_PORT)
     api_key = entry.data[CONF_API_KEY]
     use_ssl = entry.data.get(CONF_SSL, True)
+    ignore_ssl = entry.data.get(CONF_IGNORE_SSL, False)
+
+    if CONF_IGNORE_SSL not in entry.data and use_ssl is False:
+        use_ssl = True
+        ignore_ssl = True
+        _LOGGER.debug(
+            "Applying legacy SSL compatibility normalization for %s:%s "
+            "(ssl=False without ignore_ssl): normalized to ssl=True, ignore_ssl=True",
+            host,
+            port,
+        )
+        hass.config_entries.async_update_entry(
+            entry,
+            data={**entry.data, CONF_SSL: use_ssl, CONF_IGNORE_SSL: ignore_ssl},
+        )
+
+    verify_ssl = not ignore_ssl
+    _LOGGER.debug(
+        "Starting runtime setup for %s:%s (ssl=%s, ignore_ssl=%s)",
+        host,
+        port,
+        use_ssl,
+        ignore_ssl,
+    )
 
     # Get HA's aiohttp session for proper connection pooling
-    # Use verify_ssl based on whether SSL connection was established
-    session = async_get_clientsession(hass, verify_ssl=use_ssl)
+    session = async_get_clientsession(hass, verify_ssl=verify_ssl)
 
     # Create API client with injected session (using unraid_api library >=1.5.0).
     # The library handles SSL detection automatically via HTTP probe.
@@ -129,7 +153,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: UnraidConfigEntry) -> bo
         host=host,
         http_port=port,
         api_key=api_key,
-        verify_ssl=use_ssl,
+        verify_ssl=verify_ssl,
         session=session,
     )
 
@@ -137,6 +161,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: UnraidConfigEntry) -> bo
     try:
         await api_client.test_connection()
         info = await api_client.get_server_info()
+        _LOGGER.debug("Initial connectivity test succeeded for %s:%s", host, port)
         # Clear any previous auth repair issues on successful connection
         ir.async_delete_issue(hass, DOMAIN, REPAIR_AUTH_FAILED)
     except UnraidAuthenticationError as err:
@@ -152,18 +177,45 @@ async def async_setup_entry(hass: HomeAssistant, entry: UnraidConfigEntry) -> bo
             translation_key="auth_failed",
             translation_placeholders={"host": host},
         )
+        _LOGGER.warning(
+            "Authentication failed for Unraid server %s:%s: %s",
+            host,
+            port,
+            err,
+        )
         msg = f"Authentication failed for Unraid server {host}"
         raise ConfigEntryAuthFailed(msg) from err
     except UnraidSSLError as err:
         await api_client.close()
+        _LOGGER.warning(
+            "TLS certificate validation failed for Unraid server %s:%s: %s. "
+            "If this server uses a self-signed certificate, reconfigure "
+            "the integration so certificate verification can be disabled "
+            "and persisted.",
+            host,
+            port,
+            err,
+        )
         msg = f"SSL certificate error connecting to Unraid server {host}: {err}"
         raise ConfigEntryNotReady(msg) from err
     except (UnraidConnectionError, UnraidTimeoutError) as err:
         await api_client.close()
+        _LOGGER.warning(
+            "Connection failed for Unraid server %s:%s: %s",
+            host,
+            port,
+            err,
+        )
         msg = f"Failed to connect to Unraid server: {err}"
         raise ConfigEntryNotReady(msg) from err
     except UnraidAPIError as err:
         await api_client.close()
+        _LOGGER.warning(
+            "API error connecting to Unraid server %s:%s: %s",
+            host,
+            port,
+            err,
+        )
         msg = f"Unraid API error connecting to server {host}: {err}"
         raise ConfigEntryNotReady(msg) from err
 

--- a/custom_components/unraid/config_flow.py
+++ b/custom_components/unraid/config_flow.py
@@ -23,6 +23,7 @@ from unraid_api.exceptions import (
 )
 
 from .const import (
+    CONF_IGNORE_SSL,
     CONF_UPS_CAPACITY_VA,
     CONF_UPS_NOMINAL_POWER,
     DEFAULT_PORT,
@@ -52,7 +53,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize the config flow."""
         self._server_uuid: str | None = None
         self._server_hostname: str | None = None
-        self._use_ssl: bool = True  # Track whether SSL connection succeeded
+        self._use_ssl: bool = True  # HTTPS transport usage
+        self._ignore_ssl: bool = False  # TLS certificate verification disabled
 
     @staticmethod
     def async_get_options_flow(
@@ -112,11 +114,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 title = self._server_hostname or user_input[CONF_HOST]
 
                 _LOGGER.info(
-                    "Creating config entry for %s (UUID: %s) port=%s ssl=%s",
+                    "Creating config entry for %s (UUID: %s) port=%s ssl=%s "
+                    "ignore_ssl=%s",
                     title,
                     unique_id,
                     user_input.get(CONF_PORT, DEFAULT_PORT),
                     self._use_ssl,
+                    self._ignore_ssl,
                 )
                 return self.async_create_entry(
                     title=title,
@@ -125,6 +129,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_PORT: user_input.get(CONF_PORT, DEFAULT_PORT),
                         CONF_API_KEY: user_input[CONF_API_KEY],
                         CONF_SSL: self._use_ssl,
+                        CONF_IGNORE_SSL: self._ignore_ssl,
                     },
                     options={
                         CONF_UPS_CAPACITY_VA: DEFAULT_UPS_CAPACITY_VA,
@@ -188,6 +193,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Reset SSL state to default
         self._use_ssl = True
+        self._ignore_ssl = False
+        _LOGGER.debug(
+            "Starting connectivity test for %s:%s (ssl=%s, ignore_ssl=%s)",
+            host,
+            port,
+            self._use_ssl,
+            self._ignore_ssl,
+        )
 
         session = async_get_clientsession(self.hass, verify_ssl=True)
 
@@ -203,10 +216,18 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             await self._validate_connection(api_client, host)
+            _LOGGER.debug(
+                "Initial connectivity test succeeded for %s:%s "
+                "with TLS verification enabled",
+                host,
+                port,
+            )
         except SSLCertificateError as err:
             _LOGGER.debug(
-                "SSL verification failed for %s, retrying with verify_ssl=False: %s",
+                "Expected certificate verification failure for %s:%s; "
+                "retrying with verify_ssl=False: %s",
                 host,
+                port,
                 err,
             )
             await api_client.close()
@@ -221,14 +242,38 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 await self._validate_connection(fallback_client, host)
                 # Success with SSL verification disabled
-                self._use_ssl = False
+                self._use_ssl = True
+                self._ignore_ssl = True
                 _LOGGER.info(
-                    "Connected to %s with self-signed cert (SSL verify disabled)",
+                    "Connected to %s with TLS verification disabled "
+                    "due to self-signed certificate",
                     host,
                 )
-            except CannotConnectError as fallback_err:
-                # Keep original failure reason if fallback also fails
-                raise err from fallback_err
+            except SSLCertificateError as fallback_err:
+                _LOGGER.debug(
+                    "Fallback retry with verify_ssl=False still failed certificate "
+                    "validation for %s:%s: %s",
+                    host,
+                    port,
+                    fallback_err,
+                )
+                msg = (
+                    f"Cannot connect to {host} - TLS certificate validation failed "
+                    "after fallback retry"
+                )
+                raise CannotConnectError(msg) from fallback_err
+            except (
+                InvalidAuthError,
+                CannotConnectError,
+                UnsupportedVersionError,
+            ) as fallback_err:
+                _LOGGER.debug(
+                    "Fallback retry with verify_ssl=False failed for %s:%s: %s",
+                    host,
+                    port,
+                    fallback_err,
+                )
+                raise fallback_err
             finally:
                 await fallback_client.close()
         except Exception:
@@ -351,7 +396,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                 return self.async_update_reload_and_abort(
                     reauth_entry,
-                    data_updates={**user_input, CONF_SSL: self._use_ssl},
+                    data_updates={
+                        **user_input,
+                        CONF_SSL: self._use_ssl,
+                        CONF_IGNORE_SSL: self._ignore_ssl,
+                    },
                     reason="reauth_successful",
                 )
 
@@ -390,7 +439,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                     return self.async_update_reload_and_abort(
                         reconfigure_entry,
-                        data_updates={**user_input, CONF_SSL: self._use_ssl},
+                        data_updates={
+                            **user_input,
+                            CONF_SSL: self._use_ssl,
+                            CONF_IGNORE_SSL: self._ignore_ssl,
+                        },
                     )
 
                 except InvalidAuthError:

--- a/custom_components/unraid/const.py
+++ b/custom_components/unraid/const.py
@@ -63,6 +63,7 @@ PLACEHOLDER_UUIDS: Final = frozenset(
 # =============================================================================
 # Configuration Keys
 # =============================================================================
+CONF_IGNORE_SSL: Final = "ignore_ssl"
 CONF_UPS_CAPACITY_VA: Final = "ups_capacity_va"
 CONF_UPS_NOMINAL_POWER: Final = "ups_nominal_power"
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -25,6 +25,7 @@ from unraid_api.models import ServerInfo, UPSDevice, VersionInfo
 
 from custom_components.unraid.config_flow import CannotConnectError, SSLCertificateError
 from custom_components.unraid.const import (
+    CONF_IGNORE_SSL,
     CONF_UPS_CAPACITY_VA,
     CONF_UPS_NOMINAL_POWER,
     DEFAULT_PORT,
@@ -118,6 +119,7 @@ async def test_successful_connection(
         "port": DEFAULT_PORT,
         "api_key": "valid-api-key",
         "ssl": True,
+        "ignore_ssl": False,
     }
 
 
@@ -146,6 +148,7 @@ async def test_successful_connection_with_custom_port(
         "port": 8080,
         "api_key": "valid-api-key",
         "ssl": True,
+        "ignore_ssl": False,
     }
     mock_client_class.assert_called_with(
         host="unraid.local",
@@ -694,7 +697,8 @@ async def test_ssl_error_retries_with_verify_disabled(
     created_clients[1].close.assert_awaited_once()
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["result"].unique_id == "test-uuid"
-    assert result2["data"]["ssl"] is False  # SSL verification disabled for self-signed
+    assert result2["data"]["ssl"] is True
+    assert result2["data"]["ignore_ssl"] is True
 
 
 async def test_non_ssl_connection_error_does_not_retry_with_verify_disabled(
@@ -726,6 +730,39 @@ async def test_non_ssl_connection_error_does_not_retry_with_verify_disabled(
         )
 
     assert call_count == 1
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"][CONF_HOST] == "cannot_connect"
+
+
+async def test_ssl_error_on_both_attempts_returns_cannot_connect(
+    hass: HomeAssistant, mock_setup_entry: None
+) -> None:
+    """Test repeated SSL verification failures return cannot_connect (not unknown)."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    call_count = 0
+
+    def create_client(**kwargs: object) -> MagicMock:
+        nonlocal call_count
+        call_count += 1
+        mock_api = MagicMock()
+        mock_api.close = AsyncMock()
+        mock_api.test_connection = AsyncMock(
+            side_effect=SSLCertificateError("SSL certificate verify failed")
+        )
+        return mock_api
+
+    with patch(
+        "custom_components.unraid.config_flow.UnraidClient", side_effect=create_client
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: "unraid.local", CONF_API_KEY: "valid-key"},
+        )
+
+    assert call_count == 2
     assert result2["type"] is FlowResultType.FORM
     assert result2["errors"][CONF_HOST] == "cannot_connect"
 
@@ -902,6 +939,7 @@ async def test_reauth_flow_adds_ssl_flag_for_legacy_entries(
     assert result2["type"] is FlowResultType.ABORT
     assert result2["reason"] == "reauth_successful"
     assert entry.data[CONF_SSL] is True
+    assert entry.data[CONF_IGNORE_SSL] is False
 
 
 async def test_reauth_flow_updates_ssl_flag_when_cert_changes(
@@ -953,8 +991,8 @@ async def test_reauth_flow_updates_ssl_flag_when_cert_changes(
 
     assert result2["type"] is FlowResultType.ABORT
     assert result2["reason"] == "reauth_successful"
-    # SSL flag should be updated to False since cert verification failed
-    assert entry.data[CONF_SSL] is False
+    assert entry.data[CONF_SSL] is True
+    assert entry.data[CONF_IGNORE_SSL] is True
 
 
 async def test_reauth_flow_invalid_key(
@@ -1360,12 +1398,13 @@ async def test_reconfigure_flow_success(
     assert entry.data[CONF_HOST] == "192.168.1.100"
     assert entry.data[CONF_API_KEY] == "new-key"
     assert entry.data[CONF_SSL] is True
+    assert entry.data[CONF_IGNORE_SSL] is False
 
 
 async def test_reconfigure_flow_updates_ssl_flag_when_cert_changes(
     hass: HomeAssistant, mock_setup_entry: None, mock_api_client: MagicMock
 ) -> None:
-    """Test reconfigure flow clears SSL flag when SSL fallback succeeds."""
+    """Test reconfigure flow sets ignore_ssl when SSL fallback succeeds."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="tower",
@@ -1387,7 +1426,7 @@ async def test_reconfigure_flow_updates_ssl_flag_when_cert_changes(
         },
     )
 
-    # Simulate SSL error on first attempt and success on fallback without SSL.
+    # Simulate SSL error on first attempt and success with verify_ssl=False.
     mock_api_client.test_connection = AsyncMock(
         side_effect=[UnraidSSLError("SSL error"), True]
     )
@@ -1405,7 +1444,8 @@ async def test_reconfigure_flow_updates_ssl_flag_when_cert_changes(
     assert result2["reason"] == "reconfigure_successful"
     assert entry.data[CONF_HOST] == "192.168.1.100"
     assert entry.data[CONF_API_KEY] == "new-key"
-    assert entry.data[CONF_SSL] is False
+    assert entry.data[CONF_SSL] is True
+    assert entry.data[CONF_IGNORE_SSL] is True
 
 
 async def test_reconfigure_flow_connection_error(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -17,7 +17,7 @@ from custom_components.unraid import (
     async_setup_entry,
     async_unload_entry,
 )
-from custom_components.unraid.const import DEFAULT_PORT, DOMAIN
+from custom_components.unraid.const import CONF_IGNORE_SSL, DEFAULT_PORT, DOMAIN
 
 # =============================================================================
 # Fixtures
@@ -126,6 +126,53 @@ async def test_setup_entry_connection_error(
         mock_session.return_value = MagicMock()
         with pytest.raises(ConfigEntryNotReady):
             await async_setup_entry(hass, mock_config_entry)
+
+
+async def test_setup_entry_normalizes_legacy_ssl_semantics(
+    hass: HomeAssistant,
+    mock_unraid_client: MagicMock,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test legacy ssl=False entries are normalized to ssl=True/ignore_ssl=True."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="tower",
+        data={
+            CONF_HOST: "192.168.1.100",
+            CONF_API_KEY: "test-api-key",
+            CONF_PORT: DEFAULT_PORT,
+            CONF_SSL: False,
+        },
+        options={},
+        unique_id="test-uuid-123",
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "custom_components.unraid.UnraidSystemCoordinator",
+            return_value=mock_coordinator,
+        ),
+        patch(
+            "custom_components.unraid.UnraidStorageCoordinator",
+            return_value=mock_coordinator,
+        ),
+        patch(
+            "custom_components.unraid.UnraidInfraCoordinator",
+            return_value=mock_coordinator,
+        ),
+        patch("custom_components.unraid.async_get_clientsession") as mock_session,
+        patch.object(
+            hass.config_entries, "async_forward_entry_setups", return_value=None
+        ),
+    ):
+        mock_session.return_value = MagicMock()
+        result = await async_setup_entry(hass, entry)
+
+    assert result is True
+    assert entry.data[CONF_SSL] is True
+    assert entry.data[CONF_IGNORE_SSL] is True
+    mock_session.assert_called_with(hass, verify_ssl=False)
 
 
 async def test_setup_entry_captures_hardware_info(


### PR DESCRIPTION
### Motivation

- Support servers using self-signed TLS certificates by persisting an `ignore_ssl` configuration key instead of overloading `ssl` semantics.
- Normalize legacy entries that set `ssl=False` to maintain backward compatibility while making intent explicit.
- Improve diagnostics and operator guidance when TLS or connection failures occur.

### Description

- Introduce a new config key `CONF_IGNORE_SSL` and constant `CONF_IGNORE_SSL` in `const.py` and propagate it through the integration state.
- In `config_flow.py` add `_ignore_ssl` state, run an initial connectivity probe with TLS verification, retry once with `verify_ssl=False` on certificate errors, and set `ignore_ssl=True` when the fallback succeeds while still keeping `ssl=True` to indicate TLS transport is used.
- In `__init__.py` normalize legacy entries that previously used `ssl=False` by updating entries to `ssl=True` and `ignore_ssl=True`, compute `verify_ssl = not ignore_ssl` for the client session and `UnraidClient`, and add clearer debug/warning logs for auth, TLS, connection, and API errors.
- Update reauth/reconfigure flows to persist `CONF_IGNORE_SSL` alongside `CONF_SSL` when updating entries and adjust logging/messages accordingly.

### Testing

- Ran unit tests in `tests/test_config_flow.py` covering user flow, TLS fallback, reauth, and reconfigure behavior, and all updated tests passed.
- Ran unit tests in `tests/test_init.py` including the new `test_setup_entry_normalizes_legacy_ssl_semantics` and all tests passed.
- Executed the integration test subset that exercises client creation and session `verify_ssl` propagation, and they passed under pytest.
- No automated tests failed during the rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddbaec0980832b88505eeb0633b154)