### PR TITLE
Normalize and validate notification API responses; add comprehensive tests

### DIFF
--- a/custom_components/unraid/coordinator.py
+++ b/custom_components/unraid/coordinator.py
@@ -252,33 +252,84 @@ class UnraidSystemCoordinator(DataUpdateCoordinator[UnraidSystemData]):
             self._server_name,
         )
 
+    @staticmethod
+    def _normalize_notification_response(response: Any) -> list[Any]:
+        """Normalize notification responses into a list of notification records."""
+        if response is None:
+            return []
+
+        if isinstance(response, dict):
+            return list(response.get("list") or [])
+
+        model_list = getattr(response, "list", None)
+        if model_list is not None:
+            return list(model_list or [])
+
+        if isinstance(response, list):
+            return response
+
+        if isinstance(response, tuple):
+            return list(response)
+
+        _LOGGER.debug(
+            "Ignoring unexpected notification response type: %s",
+            type(response).__name__,
+        )
+        return []
+
+    @staticmethod
+    def _notification_response_shape(response: Any) -> str:
+        """Return a compact response shape string for debug logging."""
+        if isinstance(response, dict):
+            list_value = response.get("list")
+            list_count = len(list_value) if isinstance(list_value, list) else "n/a"
+            return (
+                f"dict(keys={sorted(response.keys())}, "
+                f"list_type={type(list_value).__name__}, list_count={list_count})"
+            )
+
+        if isinstance(response, list):
+            return f"list(len={len(response)})"
+
+        return type(response).__name__
+
     async def _async_get_unread_notifications(self) -> list[Any]:
         """Fetch unread notifications via available API wrapper methods."""
         _LOGGER.debug("Polling unread notifications for %s", self._server_name)
         try:
             if hasattr(self.api_client, "typed_get_notifications"):
-                notifications = await self.api_client.typed_get_notifications(
+                response = await self.api_client.typed_get_notifications(
                     notification_type="UNREAD",
                     offset=0,
                     limit=200,
                 )
-                notification_list = list(notifications)
                 _LOGGER.debug(
-                    "Fetched %d unread notifications for %s via typed API",
+                    "Unread notifications API path=typed_get_notifications shape=%s for %s",
+                    self._notification_response_shape(response),
+                    self._server_name,
+                )
+                notification_list = self._normalize_notification_response(response)
+                _LOGGER.debug(
+                    "Extracted %d unread notification records for %s via typed API",
                     len(notification_list),
                     self._server_name,
                 )
                 return notification_list
 
             if hasattr(self.api_client, "get_notifications"):
-                notifications = await self.api_client.get_notifications(
+                response = await self.api_client.get_notifications(
                     notification_type="UNREAD",
                     offset=0,
                     limit=200,
                 )
-                notification_list = list(notifications)
                 _LOGGER.debug(
-                    "Fetched %d unread notifications for %s via API",
+                    "Unread notifications API path=get_notifications shape=%s for %s",
+                    self._notification_response_shape(response),
+                    self._server_name,
+                )
+                notification_list = self._normalize_notification_response(response)
+                _LOGGER.debug(
+                    "Extracted %d unread notification records for %s via API",
                     len(notification_list),
                     self._server_name,
                 )

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1624,6 +1624,14 @@ async def test_storage_coordinator_runtime_error_handled(
 # =============================================================================
 
 
+class _NotificationListWrapper:
+    """Test helper to mimic typed notification wrapper objects."""
+
+    def __init__(self, notifications: list[dict[str, str]]) -> None:
+        """Initialize wrapper with notification list."""
+        self.list = notifications
+
+
 def _make_notification(
     notification_id: str,
     timestamp: str,
@@ -1742,6 +1750,181 @@ async def test_notification_events_emit_oldest_first(
     assert listener.call_count == 2
     ordered_ids = [call.args[0].notification_id for call in listener.call_args_list]
     assert ordered_ids == ["older", "newer"]
+
+
+
+
+@pytest.mark.asyncio
+async def test_notification_events_none_response_ignored(
+    hass, mock_api_client, mock_config_entry, caplog
+):
+    """Test None notification response yields no events and no invalid-ID warning."""
+    mock_api_client.typed_get_notifications.return_value = None
+    coordinator = UnraidSystemCoordinator(
+        hass, mock_api_client, "tower", mock_config_entry
+    )
+    listener = MagicMock()
+    coordinator.async_add_event_listener(listener, "notification_created")
+
+    await coordinator._async_update_data()
+
+    listener.assert_not_called()
+    assert "Skipping notification without ID" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_notification_events_string_response_ignored(
+    hass, mock_api_client, mock_config_entry, caplog
+):
+    """Test string notification response is ignored instead of iterated by character."""
+    mock_api_client.typed_get_notifications.return_value = "oops"
+    coordinator = UnraidSystemCoordinator(
+        hass, mock_api_client, "tower", mock_config_entry
+    )
+
+    await coordinator._async_update_data()
+
+    assert "Skipping notification without ID" not in caplog.text
+    assert coordinator._seen_notification_ids == set()
+
+
+@pytest.mark.asyncio
+async def test_notification_events_scalar_response_ignored(
+    hass, mock_api_client, mock_config_entry, caplog
+):
+    """Test numeric notification response is ignored safely."""
+    mock_api_client.typed_get_notifications.return_value = 123
+    coordinator = UnraidSystemCoordinator(
+        hass, mock_api_client, "tower", mock_config_entry
+    )
+
+    await coordinator._async_update_data()
+
+    assert "Skipping notification without ID" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_notification_events_model_list_response_supported(
+    hass, mock_api_client, mock_config_entry
+):
+    """Test wrapper/model notification response with `.list` is supported."""
+    mock_api_client.typed_get_notifications.return_value = _NotificationListWrapper(
+        [_make_notification("existing", "2026-04-24T08:01:04.000Z")]
+    )
+    coordinator = UnraidSystemCoordinator(
+        hass, mock_api_client, "tower", mock_config_entry
+    )
+    listener = MagicMock()
+    coordinator.async_add_event_listener(listener, "notification_created")
+
+    await coordinator._async_update_data()
+
+    mock_api_client.typed_get_notifications.return_value = _NotificationListWrapper(
+        [
+            _make_notification("existing", "2026-04-24T08:01:04.000Z"),
+            _make_notification("new", "2026-04-24T08:03:04.000Z"),
+        ]
+    )
+    await coordinator._async_update_data()
+
+    assert listener.call_count == 1
+    assert listener.call_args.args[0].notification_id == "new"
+
+@pytest.mark.asyncio
+async def test_notification_events_extract_from_dict_response_and_emit(
+    hass, mock_api_client, mock_config_entry
+):
+    """Test dict notification responses extract list payload and emit unseen events."""
+    mock_api_client.typed_get_notifications.return_value = {
+        "overview": {"unread": {"total": 1}},
+        "list": [_make_notification("existing", "2026-04-24T08:01:04.000Z")],
+    }
+    coordinator = UnraidSystemCoordinator(
+        hass, mock_api_client, "tower", mock_config_entry
+    )
+    listener = MagicMock()
+    coordinator.async_add_event_listener(listener, "notification_created")
+
+    await coordinator._async_update_data()
+    listener.assert_not_called()
+
+    mock_api_client.typed_get_notifications.return_value = {
+        "overview": {"unread": {"total": 2}},
+        "list": [
+            _make_notification("existing", "2026-04-24T08:01:04.000Z"),
+            _make_notification("new", "2026-04-24T08:03:04.000Z"),
+        ],
+    }
+    await coordinator._async_update_data()
+
+    assert listener.call_count == 1
+    assert listener.call_args.args[0].event_type == "notification_created"
+    assert listener.call_args.args[0].notification_id == "new"
+
+
+@pytest.mark.asyncio
+async def test_notification_events_empty_dict_list_does_not_warn_missing_id(
+    hass, mock_api_client, mock_config_entry, caplog
+):
+    """Test dict responses with empty list do not process top-level keys as items."""
+    mock_api_client.typed_get_notifications.return_value = {
+        "overview": {"unread": {"total": 0}},
+        "list": [],
+    }
+    coordinator = UnraidSystemCoordinator(
+        hass, mock_api_client, "tower", mock_config_entry
+    )
+
+    await coordinator._async_update_data()
+
+    assert "Skipping notification without ID" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_notification_events_list_response_still_works(
+    hass, mock_api_client, mock_config_entry
+):
+    """Test list notification responses remain supported."""
+    mock_api_client.typed_get_notifications.return_value = [
+        _make_notification("existing", "2026-04-24T08:01:04.000Z")
+    ]
+    coordinator = UnraidSystemCoordinator(
+        hass, mock_api_client, "tower", mock_config_entry
+    )
+    listener = MagicMock()
+    coordinator.async_add_event_listener(listener, "notification_created")
+
+    await coordinator._async_update_data()
+
+    mock_api_client.typed_get_notifications.return_value = [
+        _make_notification("existing", "2026-04-24T08:01:04.000Z"),
+        _make_notification("new", "2026-04-24T08:03:04.000Z"),
+    ]
+    await coordinator._async_update_data()
+
+    assert listener.call_count == 1
+    assert listener.call_args.args[0].notification_id == "new"
+
+
+@pytest.mark.asyncio
+async def test_notification_response_dict_keys_never_processed_as_items(
+    hass, mock_api_client, mock_config_entry, caplog
+):
+    """Regression test for dict key iteration bug in notification extraction."""
+    mock_api_client.typed_get_notifications.return_value = {
+        "overview": {"unread": {"total": 1}},
+        "list": [_make_notification("only", "2026-04-24T08:01:04.000Z")],
+    }
+    coordinator = UnraidSystemCoordinator(
+        hass, mock_api_client, "tower", mock_config_entry
+    )
+
+    await coordinator._async_update_data()
+
+    assert "Skipping notification without ID" not in caplog.text
+    assert "overview" not in coordinator._seen_notification_ids
+    assert "list" not in coordinator._seen_notification_ids
+    assert "only" in coordinator._seen_notification_ids
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation

- Prevent incorrect iteration over unexpected notification API response shapes (e.g. strings, dicts, model wrappers) that caused spurious warnings and incorrect seen-ID handling.
- Make debugging easier by reporting a compact response shape for the notification API path used.
- Ensure the coordinator supports both typed/model and plain dict/list responses from the Unraid client.

### Description

- Added `UnraidSystemCoordinator._normalize_notification_response` to convert various notification response shapes into a normalized `list` of notification records and to ignore unsupported scalar or unexpected types.
- Added `UnraidSystemCoordinator._notification_response_shape` to produce compact debug strings describing the response shape and size for logging.
- Updated `_async_get_unread_notifications` to use the new normalization and shape-logging for both `typed_get_notifications` and `get_notifications` paths and to avoid iterating over dict keys or strings as items.
- Added many unit tests in `tests/test_coordinator.py` including a `_NotificationListWrapper` helper and tests covering `None`, string, numeric, dict-with-`list`, model-wrapper-with-`.list`, plain-list responses, ordering, and regression checks to ensure dict keys are not treated as items.

### Testing

- Ran the coordinator unit tests in `tests/test_coordinator.py` (including the new notification response tests) with `pytest` and all tests completed successfully.
- Verified that notification event emission behavior remains correct for list responses and now safely ignores or normalizes unexpected response shapes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3349dca04832b957ae6e36cc77b0b)