### PR TITLE
fix: harden websocket notification disconnect handling

### DIFF
--- a/custom_components/unraid/websocket.py
+++ b/custom_components/unraid/websocket.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+
+import aiohttp
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -70,6 +72,7 @@ class UnraidWebSocketManager:
         self._last_ups_refresh: float = 0.0
         self._last_notification_refresh: float = 0.0
         self._last_parity_refresh: float = 0.0
+        self._recoverable_error_counts: dict[str, int] = {}
 
     async def async_start(self) -> None:
         """Start all WebSocket subscriptions as background tasks."""
@@ -151,16 +154,22 @@ class UnraidWebSocketManager:
             except (UnraidConnectionError, UnraidTimeoutError, UnraidAPIError) as err:
                 if not self._running:
                     return
-                _LOGGER.debug(
-                    "WebSocket %s disconnected for %s: %s — retrying in %ss",
-                    name,
-                    self._server_name,
-                    err,
-                    retry_delay,
-                )
+                self._log_recoverable_disconnect(name, err, retry_delay)
+
+            except (
+                aiohttp.ClientConnectionResetError,
+                aiohttp.ClientConnectionError,
+                aiohttp.ClientPayloadError,
+                asyncio.TimeoutError,
+                ConnectionResetError,
+                OSError,
+            ) as err:
+                if not self._running:
+                    return
+                self._log_recoverable_disconnect(name, err, retry_delay)
 
             except asyncio.CancelledError:
-                return
+                raise
 
             except Exception:
                 if not self._running:
@@ -180,6 +189,39 @@ class UnraidWebSocketManager:
             except asyncio.CancelledError:
                 return
             retry_delay = min(retry_delay * WS_RETRY_BACKOFF_FACTOR, WS_MAX_RETRY_DELAY)
+
+    def _log_recoverable_disconnect(
+        self,
+        subscription_name: str,
+        err: Exception,
+        retry_delay: float,
+    ) -> None:
+        """Log recoverable disconnections with bounded verbosity."""
+        count = self._recoverable_error_counts.get(subscription_name, 0) + 1
+        self._recoverable_error_counts[subscription_name] = count
+
+        if count == 1 or count % 10 == 0:
+            _LOGGER.warning(
+                "Recoverable WebSocket disconnect in %s for %s: %s "
+                "(attempt %s, retrying in %ss)",
+                subscription_name,
+                self._server_name,
+                err,
+                count,
+                retry_delay,
+                exc_info=_LOGGER.isEnabledFor(logging.DEBUG),
+            )
+            return
+
+        _LOGGER.debug(
+            "Recoverable WebSocket disconnect in %s for %s: %s "
+            "(attempt %s, retrying in %ss)",
+            subscription_name,
+            self._server_name,
+            err,
+            count,
+            retry_delay,
+        )
 
     def _should_trigger_refresh(self, last_refresh_time: float) -> bool:
         """Return True if enough time has elapsed since the last refresh."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1705,6 +1705,33 @@ async def test_notification_events_emit_new_unread_once(
 
 
 @pytest.mark.asyncio
+async def test_notification_event_dedup_when_websocket_and_polling_overlap(
+    hass, mock_api_client, mock_config_entry
+):
+    """Same notification ID seen in overlapping refreshes emits once."""
+    mock_api_client.typed_get_notifications.return_value = [
+        _make_notification("existing", "2026-04-24T08:01:04.000Z"),
+    ]
+    coordinator = UnraidSystemCoordinator(
+        hass, mock_api_client, "tower", mock_config_entry
+    )
+    listener = MagicMock()
+    coordinator.async_add_event_listener(listener, "notification_created")
+
+    await coordinator._async_update_data()
+
+    mock_api_client.typed_get_notifications.return_value = [
+        _make_notification("existing", "2026-04-24T08:01:04.000Z"),
+        _make_notification("same-id", "2026-04-24T08:03:04.000Z"),
+    ]
+    await coordinator._async_update_data()  # WebSocket-triggered refresh
+    await coordinator._async_update_data()  # Normal polling refresh
+
+    assert listener.call_count == 1
+    assert listener.call_args.args[0].notification_id == "same-id"
+
+
+@pytest.mark.asyncio
 async def test_notification_events_ignore_archived_notifications(
     hass, mock_api_client, mock_config_entry
 ):

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+
+import aiohttp
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -572,3 +574,45 @@ class TestReconnection:
         await manager._run_subscription("test", cancelled_handler)
 
         assert call_count == 1
+
+
+    @pytest.mark.asyncio
+    async def test_client_connection_reset_is_recoverable(self, caplog: pytest.LogCaptureFixture) -> None:
+        """ClientConnectionResetError is treated as recoverable and retried."""
+        call_count = 0
+
+        async def failing_handler() -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 3:
+                manager._running = False
+                return
+            raise aiohttp.ClientConnectionResetError("Cannot write to closing transport")
+
+        manager = _make_manager()
+        manager._running = True
+
+        with patch("custom_components.unraid.websocket.asyncio.sleep") as mock_sleep:
+            mock_sleep.return_value = None
+            with caplog.at_level("WARNING"):
+                await manager._run_subscription("notification_added", failing_handler)
+
+        assert call_count == 3
+        assert mock_sleep.call_count >= 2
+        assert "Unexpected error in notification_added WebSocket" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_still_logs_error(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Unexpected exceptions remain error-level with traceback."""
+
+        async def bad_handler() -> None:
+            manager._running = False
+            raise ValueError("boom")
+
+        manager = _make_manager()
+        manager._running = True
+
+        with caplog.at_level("ERROR"):
+            await manager._run_subscription("notification_added", bad_handler)
+
+        assert "Unexpected error in notification_added WebSocket" in caplog.text


### PR DESCRIPTION
### Motivation
- Reduce noisy ERROR tracebacks for normal/recoverable WebSocket close races (e.g. "Cannot write to closing transport") while preserving reconnect/backoff behavior and true error visibility. 
- Ensure subscription tasks cancel cleanly during unload/shutdown and avoid log spam when reconnects happen repeatedly. 
- Prevent duplicate notification events when both polling and WebSocket-triggered refreshes see the same notification ID.

### Description
- Treat common transport/network disconnects as recoverable in `UnraidWebSocketManager._run_subscription()` by adding explicit exception handling for `aiohttp.ClientConnectionResetError`, `aiohttp.ClientConnectionError`, `aiohttp.ClientPayloadError`, `asyncio.TimeoutError`, `ConnectionResetError`, and `OSError`. 
- Add `_log_recoverable_disconnect()` and a per-subscription counter to bound verbosity (warning on first and every 10th occurrence, debug otherwise) and include server and subscription names; show traceback only when debug logging is enabled. 
- Preserve cancellation semantics by re-raising `asyncio.CancelledError` so task cancellation propagates during unload/shutdown. 
- Keep unexpected exceptions logged at ERROR with a traceback so fatal issues remain visible. 
- Add/adjust unit tests: new/updated tests in `tests/test_websocket.py` to assert that `ClientConnectionResetError` is treated as recoverable and that unexpected exceptions still log ERROR, and a new test in `tests/test_coordinator.py` to ensure notification deduplication when WebSocket and polling refreshes overlap.

### Testing
- Added unit tests: `TestReconnection.test_client_connection_reset_is_recoverable`, `TestReconnection.test_unexpected_error_still_logs_error` (in `tests/test_websocket.py`) and `test_notification_event_dedup_when_websocket_and_polling_overlap` (in `tests/test_coordinator.py`).
- Attempted to run the targeted test subset with `pytest -q tests/test_websocket.py tests/test_coordinator.py -k "notification or websocket"`, but the test run failed in this environment due to a missing test dependency (`pytest_homeassistant_custom_component`), so full automated verification could not be completed here. 
- Lint attempted with `./script/lint` but could not run in this environment because the project virtualenv is not bootstrapped; developers should run the project's lint and full test suite in a properly provisioned dev environment before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35ad8b160832b8876d18db8f61692)